### PR TITLE
Proxying

### DIFF
--- a/composer-path-repos/libraries/hacky-proxy/composer.json
+++ b/composer-path-repos/libraries/hacky-proxy/composer.json
@@ -6,6 +6,9 @@
         "zendframework/zend-diactoros": "^1",
         "jenssegers/proxy": "^3.0"
     },
+    "autoload": {
+        "psr-4": { "Stevector\\HackyProxy\\": "src/" }
+    },
     "authors": [
         {
             "name": "Steve Persch",

--- a/composer-path-repos/libraries/hacky-proxy/composer.json
+++ b/composer-path-repos/libraries/hacky-proxy/composer.json
@@ -7,7 +7,8 @@
         "jenssegers/proxy": "^3.0"
     },
     "autoload": {
-        "psr-4": { "Stevector\\HackyProxy\\": "src/" }
+        "psr-4": { "Stevector\\HackyProxy\\": "src/" },
+        "files": [ "fun.php" ]
     },
     "authors": [
         {

--- a/composer-path-repos/libraries/hacky-proxy/composer.json
+++ b/composer-path-repos/libraries/hacky-proxy/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "stevector/hacky-proxy",
+    "description": "PoC proxying to GCP Buckets from Pantheon",
+    "type": "library",
+    "require": {
+        "zendframework/zend-diactoros": "^1",
+        "jenssegers/proxy": "^3.0"
+    },
+    "authors": [
+        {
+            "name": "Steve Persch",
+            "email": "steve.persch@pantheon.io"
+        }
+    ]
+}

--- a/composer-path-repos/libraries/hacky-proxy/composer.json
+++ b/composer-path-repos/libraries/hacky-proxy/composer.json
@@ -8,7 +8,7 @@
     },
     "autoload": {
         "psr-4": { "Stevector\\HackyProxy\\": "src/" },
-        "files": [ "fun.php" ]
+        "files": [ "proxy-loader.php" ]
     },
     "authors": [
         {

--- a/composer-path-repos/libraries/hacky-proxy/fun.php
+++ b/composer-path-repos/libraries/hacky-proxy/fun.php
@@ -1,0 +1,4 @@
+<?php
+
+
+$hackyproxy = new \Stevector\HackyProxy\PantheonToGCPBucket();

--- a/composer-path-repos/libraries/hacky-proxy/proxy-loader.php
+++ b/composer-path-repos/libraries/hacky-proxy/proxy-loader.php
@@ -1,4 +1,3 @@
 <?php
 
-
 $hackyproxy = new \Stevector\HackyProxy\PantheonToGCPBucket();

--- a/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
+++ b/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
@@ -7,21 +7,17 @@ use Proxy\Adapter\Guzzle\GuzzleAdapter;
 use Proxy\Filter\RemoveEncodingFilter;
 use Zend\Diactoros\ServerRequestFactory;
 
-
-
 class PantheonToGCPBucket {
 
 
   function __construct()
   {
 
-
-    if  (1===3) {
-
-
-      $fake_server = [
-//  'REQUEST_URI' =>  '/pr-19' . $_SERVER['REQUEST_URI']
-      ];
+      if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && $_ENV['PANTHEON_ENVIRONMENT'] !== 'lando') {
+        $prefix = $_ENV['PANTHEON_ENVIRONMENT'];
+      } else {
+        $prefix = 'pr-19';
+      }
 
       $fake_server = $_SERVER;
       $fake_server['REQUEST_URI'];
@@ -30,38 +26,27 @@ class PantheonToGCPBucket {
         $fake_server['REQUEST_URI'] = '/index.html';
       }
 
-      $fake_server['REQUEST_URI'] = '/' . $_ENV['PANTHEON_ENVIRONMENT'] . $fake_server['REQUEST_URI'];
+      $fake_server['REQUEST_URI'] = '/' . $prefix . $fake_server['REQUEST_URI'];
 
       $request = ServerRequestFactory::fromGlobals($fake_server);
 
-// Create a guzzle client
-      $guzzle = new GuzzleHttp\Client();
+      // Create a guzzle client
+      $guzzle = new \GuzzleHttp\Client();
 
-// Create the proxy instance
+      // Create the proxy instance
       $proxy = new Proxy(new GuzzleAdapter($guzzle));
 
-// Add a response filter that removes the encoding headers.
+      // Add a response filter that removes the encoding headers.
       $proxy->filter(new RemoveEncodingFilter());
 
       $url = 'http://gcp-gatsby-bucket.stevector.com/';
 
-//$url = rtrim($url, '/');
-// Forward the request and get the response.
+      // Forward the request and get the response.
       $response = $proxy->forward($request)->to($url);
 
 
-
-//print_r($response);
-
-// Output response to the browser.
-      (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
-      print_r($url);
-      die();
+      // Output response to the browser.
+      (new \Zend\Diactoros\Response\SapiEmitter)->emit($response);
+      exit();
     }
-
-
-
-  }
-
 }
-

--- a/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
+++ b/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
@@ -1,0 +1,52 @@
+<?php
+
+use Proxy\Proxy;
+use Proxy\Adapter\Guzzle\GuzzleAdapter;
+use Proxy\Filter\RemoveEncodingFilter;
+use Zend\Diactoros\ServerRequestFactory;
+
+
+
+if  (1===3) {
+
+
+  $fake_server = [
+//  'REQUEST_URI' =>  '/pr-19' . $_SERVER['REQUEST_URI']
+  ];
+
+  $fake_server = $_SERVER;
+  $fake_server['REQUEST_URI'];
+
+  if (empty($fake_server['REQUEST_URI']) || $fake_server['REQUEST_URI'] == '/') {
+    $fake_server['REQUEST_URI'] = '/index.html';
+  }
+
+  $fake_server['REQUEST_URI'] = '/' . $_ENV['PANTHEON_ENVIRONMENT'] . $fake_server['REQUEST_URI'];
+
+  $request = ServerRequestFactory::fromGlobals($fake_server);
+
+// Create a guzzle client
+  $guzzle = new GuzzleHttp\Client();
+
+// Create the proxy instance
+  $proxy = new Proxy(new GuzzleAdapter($guzzle));
+
+// Add a response filter that removes the encoding headers.
+  $proxy->filter(new RemoveEncodingFilter());
+
+  $url = 'http://gcp-gatsby-bucket.stevector.com/';
+
+//$url = rtrim($url, '/');
+// Forward the request and get the response.
+  $response = $proxy->forward($request)->to($url);
+
+
+
+//print_r($response);
+
+// Output response to the browser.
+  (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
+  print_r($url);
+  die();
+}
+

--- a/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
+++ b/composer-path-repos/libraries/hacky-proxy/src/PantheonToGCPBucket.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Stevector\HackyProxy;
+
 use Proxy\Proxy;
 use Proxy\Adapter\Guzzle\GuzzleAdapter;
 use Proxy\Filter\RemoveEncodingFilter;
@@ -7,46 +9,59 @@ use Zend\Diactoros\ServerRequestFactory;
 
 
 
-if  (1===3) {
+class PantheonToGCPBucket {
 
 
-  $fake_server = [
+  function __construct()
+  {
+
+
+    if  (1===3) {
+
+
+      $fake_server = [
 //  'REQUEST_URI' =>  '/pr-19' . $_SERVER['REQUEST_URI']
-  ];
+      ];
 
-  $fake_server = $_SERVER;
-  $fake_server['REQUEST_URI'];
+      $fake_server = $_SERVER;
+      $fake_server['REQUEST_URI'];
 
-  if (empty($fake_server['REQUEST_URI']) || $fake_server['REQUEST_URI'] == '/') {
-    $fake_server['REQUEST_URI'] = '/index.html';
-  }
+      if (empty($fake_server['REQUEST_URI']) || $fake_server['REQUEST_URI'] == '/') {
+        $fake_server['REQUEST_URI'] = '/index.html';
+      }
 
-  $fake_server['REQUEST_URI'] = '/' . $_ENV['PANTHEON_ENVIRONMENT'] . $fake_server['REQUEST_URI'];
+      $fake_server['REQUEST_URI'] = '/' . $_ENV['PANTHEON_ENVIRONMENT'] . $fake_server['REQUEST_URI'];
 
-  $request = ServerRequestFactory::fromGlobals($fake_server);
+      $request = ServerRequestFactory::fromGlobals($fake_server);
 
 // Create a guzzle client
-  $guzzle = new GuzzleHttp\Client();
+      $guzzle = new GuzzleHttp\Client();
 
 // Create the proxy instance
-  $proxy = new Proxy(new GuzzleAdapter($guzzle));
+      $proxy = new Proxy(new GuzzleAdapter($guzzle));
 
 // Add a response filter that removes the encoding headers.
-  $proxy->filter(new RemoveEncodingFilter());
+      $proxy->filter(new RemoveEncodingFilter());
 
-  $url = 'http://gcp-gatsby-bucket.stevector.com/';
+      $url = 'http://gcp-gatsby-bucket.stevector.com/';
 
 //$url = rtrim($url, '/');
 // Forward the request and get the response.
-  $response = $proxy->forward($request)->to($url);
+      $response = $proxy->forward($request)->to($url);
 
 
 
 //print_r($response);
 
 // Output response to the browser.
-  (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
-  print_r($url);
-  die();
+      (new Zend\Diactoros\Response\SapiEmitter)->emit($response);
+      print_r($url);
+      die();
+    }
+
+
+
+  }
+
 }
 

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "path",
+            "url": "composer-path-repos/libraries/hacky-proxy"
         }
     ],
     "require": {
@@ -23,10 +27,13 @@
         "drupal/rel_to_abs": "^1.2",
         "drush-ops/behat-drush-endpoint": "^9.3",
         "drush/drush": "~8.3",
+        "jenssegers/proxy": "^3.0",
         "pantheon-systems/quicksilver-pushback": "^2",
         "rvtraveller/qs-composer-installer": "^1.1",
+        "stevector/hacky-proxy": "dev-proxying",
         "webflo/drupal-core-strict": "^8.6.15",
-        "zaporylie/composer-drupal-optimizations": "^1.0"
+        "zaporylie/composer-drupal-optimizations": "^1.0",
+        "zendframework/zend-diactoros": "^1"
     },
     "require-dev": {
         "behat/behat": "3.*",
@@ -48,7 +55,7 @@
     "conflict": {
             "drupal/drupal": "*"
     },
-    "minimum-stability": "alpha",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,11 @@
         "drupal/rel_to_abs": "^1.2",
         "drush-ops/behat-drush-endpoint": "^9.3",
         "drush/drush": "~8.3",
-        "jenssegers/proxy": "^3.0",
         "pantheon-systems/quicksilver-pushback": "^2",
         "rvtraveller/qs-composer-installer": "^1.1",
         "stevector/hacky-proxy": "dev-proxying",
         "webflo/drupal-core-strict": "^8.6.15",
-        "zaporylie/composer-drupal-optimizations": "^1.0",
-        "zendframework/zend-diactoros": "^1"
+        "zaporylie/composer-drupal-optimizations": "^1.0"
     },
     "require-dev": {
         "behat/behat": "3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3507,7 +3507,7 @@
             "dist": {
                 "type": "path",
                 "url": "composer-path-repos/libraries/hacky-proxy",
-                "reference": "1cd9aa122456546ad164ce33970613d615d12546",
+                "reference": "f42deab938093933d18a8d1c3ddf34534aa4e068",
                 "shasum": null
             },
             "require": {
@@ -3520,7 +3520,7 @@
                     "Stevector\\HackyProxy\\": "src/"
                 },
                 "files": [
-                    "fun.php"
+                    "proxy-loader.php"
                 ]
             },
             "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -3507,7 +3507,7 @@
             "dist": {
                 "type": "path",
                 "url": "composer-path-repos/libraries/hacky-proxy",
-                "reference": "dec92b9ee1b56e4a1143789e04b5845949a3f1b1",
+                "reference": "1cd9aa122456546ad164ce33970613d615d12546",
                 "shasum": null
             },
             "require": {
@@ -3518,7 +3518,10 @@
             "autoload": {
                 "psr-4": {
                     "Stevector\\HackyProxy\\": "src/"
-                }
+                },
+                "files": [
+                    "fun.php"
+                ]
             },
             "authors": [
                 {

--- a/composer.lock
+++ b/composer.lock
@@ -3507,7 +3507,7 @@
             "dist": {
                 "type": "path",
                 "url": "composer-path-repos/libraries/hacky-proxy",
-                "reference": "7beacd2895df31be1f0fb7b35d29a02130613b7b",
+                "reference": "dec92b9ee1b56e4a1143789e04b5845949a3f1b1",
                 "shasum": null
             },
             "require": {
@@ -3515,6 +3515,11 @@
                 "zendframework/zend-diactoros": "^1"
             },
             "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Stevector\\HackyProxy\\": "src/"
+                }
+            },
             "authors": [
                 {
                     "name": "Steve Persch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b63dc921af02cdd251734e70d5095d6",
+    "content-hash": "54577b23d1f3d074bcebd55ddda9da7f",
     "packages": [
         {
             "name": "alchemy/zippy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7989ea613de50b55ac7188572a38d6ee",
+    "content-hash": "9b63dc921af02cdd251734e70d5095d6",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2594,6 +2594,60 @@
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
+            "name": "jenssegers/proxy",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jenssegers/php-proxy.git",
+                "reference": "74bd607f6a10116e18abf33a6b47ccf535874102"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jenssegers/php-proxy/zipball/74bd607f6a10116e18abf33a6b47ccf535874102",
+                "reference": "74bd607f6a10116e18abf33a6b47ccf535874102",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": "^5.6 || ^7.0",
+                "psr/http-message": "^1.0",
+                "relay/relay": "^1.0",
+                "zendframework/zend-diactoros": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Proxy\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jens Segers",
+                    "homepage": "https://jenssegers.com"
+                },
+                {
+                    "name": "Ota Mares",
+                    "email": "o.mares@rebuy.de",
+                    "homepage": "http://www.rebuy.de"
+                }
+            ],
+            "description": "Proxy library that forwards requests to the desired url and returns the response.",
+            "homepage": "https://github.com/jenssegers/php-proxy",
+            "keywords": [
+                "proxy"
+            ],
+            "time": "2019-08-03T09:01:50+00:00"
+        },
+        {
             "name": "masterminds/html5",
             "version": "2.3.0",
             "source": {
@@ -3271,6 +3325,51 @@
             "time": "2018-10-13T15:16:03+00:00"
         },
         {
+            "name": "relay/relay",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/relayphp/Relay.Relay.git",
+                "reference": "e835fc45351b7a92a6fdf2a36be7bd59ef56c8ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/relayphp/Relay.Relay/zipball/e835fc45351b7a92a6fdf2a36be7bd59ef56c8ae",
+                "reference": "e835fc45351b7a92a6fdf2a36be7bd59ef56c8ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "psr/http-message": "~1.0"
+            },
+            "require-dev": {
+                "zendframework/zend-diactoros": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Relay\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Relay.Relay Contributors",
+                    "homepage": "https://github.com/relayphp/Relay.Relay/contributors"
+                }
+            ],
+            "description": "A PSR-7 middleware dispatcher.",
+            "homepage": "https://github.com/relayphp/Relay.Relay",
+            "keywords": [
+                "middleware",
+                "psr-7"
+            ],
+            "time": "2015-12-17T18:18:30+00:00"
+        },
+        {
             "name": "rvtraveller/qs-composer-installer",
             "version": "1.1",
             "source": {
@@ -3401,6 +3500,28 @@
             ],
             "description": "Automatic BASH completion for Symfony Console Component based applications.",
             "time": "2019-04-29T03:20:18+00:00"
+        },
+        {
+            "name": "stevector/hacky-proxy",
+            "version": "dev-proxying",
+            "dist": {
+                "type": "path",
+                "url": "composer-path-repos/libraries/hacky-proxy",
+                "reference": "7beacd2895df31be1f0fb7b35d29a02130613b7b",
+                "shasum": null
+            },
+            "require": {
+                "jenssegers/proxy": "^3.0",
+                "zendframework/zend-diactoros": "^1"
+            },
+            "type": "library",
+            "authors": [
+                {
+                    "name": "Steve Persch",
+                    "email": "steve.persch@pantheon.io"
+                }
+            ],
+            "description": "PoC proxying to GCP Buckets from Pantheon"
         },
         {
             "name": "symfony-cmf/routing",
@@ -5201,6 +5322,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Locked core dependencies",
+            "abandoned": "drupal/core-recommended",
             "time": "2019-08-07T19:30:50+00:00"
         },
         {
@@ -5526,6 +5648,7 @@
                 "psr",
                 "psr-7"
             ],
+            "abandoned": "laminas/laminas-diactoros",
             "time": "2017-08-17T21:21:00+00:00"
         },
         {
@@ -5570,6 +5693,7 @@
                 "escaper",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-escaper",
             "time": "2016-06-30T19:48:38+00:00"
         },
         {
@@ -5631,6 +5755,7 @@
                 "feed",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-feed",
             "time": "2016-02-11T18:54:29+00:00"
         },
         {
@@ -5676,6 +5801,7 @@
                 "stdlib",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-stdlib",
             "time": "2016-04-12T21:19:36+00:00"
         }
     ],
@@ -6179,6 +6305,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -7991,9 +8118,10 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "alpha",
+    "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/graphql": 20
+        "drupal/graphql": 20,
+        "stevector/hacky-proxy": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
An in-progress PR showing PHP proxying to a GCP Bucket.

Some of the tricky parts are
- path munging. `http://example.com/some-article` maps to `http://gcp-gatsby-bucket.stevector.com/[environment-name]/some-article`
- The GCP bucket needs to be accessible at a public domain.  I used `gcp-gatsby-bucket.stevector.com`
- the bucket needs to be configured to serve `index.html` and `404.html` https://cloud.google.com/storage/docs/gsutil/commands/web
- The proxying should alter HTTP headers to make responses publicly cacheable.

I used `jenssegers/proxy` here but I would prefer this be done with Symfony components already required by Drupal 8.

Determining which paths to proxy and which to serve from the CMS is harder to do in Drupal than WordPress, so let's develop in WordPress first.
